### PR TITLE
GapExtension を削除する

### DIFF
--- a/frontend/lib/utils/gap.dart
+++ b/frontend/lib/utils/gap.dart
@@ -1,9 +1,0 @@
-import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
-
-extension GapExtension on Iterable<Widget> {
-  List<Widget> gap(double value) => expand((item) sync* {
-        yield Gap(value);
-        yield item;
-      }).skip(1).toList();
-}


### PR DESCRIPTION
resolve #244

flutter 3.27 で column, row に spacing が追加されたので、それ使え