### PR TITLE
crontabでtz設定がリセットされちゃってたのを修正

### DIFF
--- a/functions/src/core/crontab.test.ts
+++ b/functions/src/core/crontab.test.ts
@@ -1,29 +1,137 @@
 import { DateTime } from "luxon";
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { crontab } from "./crontab.js";
 
 describe("crontab", async () => {
-  test("should execute the task when the time matches the crontab", async () => {
-    const fn = vi.fn();
+  describe("時刻が JST の場合", () => {
+    describe("分指定の場合", () => {
+      describe("時刻が crontab に一致する場合", () => {
+        it("実行されること", async () => {
+          const fn = vi.fn();
 
-    const scheduled = crontab("0 * * * *", () =>
-      Promise.resolve({ default: fn }),
-    );
+          const scheduled = crontab("5 * * * *", () =>
+            Promise.resolve({ default: fn }),
+          );
 
-    await scheduled(DateTime.local(2024, 1, 1, 0, 0, { zone: "asia/tokyo" }));
+          await scheduled(DateTime.fromISO("2025-03-02T07:05:00.000+09:00"));
+          await scheduled(DateTime.fromISO("2025-03-02T07:05:01.000+09:00")); // 秒の違いは無視される
 
-    expect(fn).toHaveBeenCalledTimes(1);
+          expect(fn).toHaveBeenCalledTimes(2);
+        });
+      });
+
+      describe("時刻が crontab に一致しない場合", () => {
+        it("実行されないこと", async () => {
+          const fn = vi.fn();
+
+          const scheduled = crontab("5 * * * *", () =>
+            Promise.resolve({ default: fn }),
+          );
+
+          await scheduled(DateTime.fromISO("2025-03-02T07:04:00.000+09:00"));
+          await scheduled(DateTime.fromISO("2025-03-02T07:06:00.000+09:00"));
+
+          expect(fn).toHaveBeenCalledTimes(0);
+        });
+      });
+    });
+
+    describe("時指定の場合", () => {
+      describe("時刻が crontab に一致する場合", () => {
+        it("実行されること", async () => {
+          const fn = vi.fn();
+
+          const scheduled = crontab("0 5 * * *", () =>
+            Promise.resolve({ default: fn }),
+          );
+
+          await scheduled(DateTime.fromISO("2025-03-02T05:00:00.000+09:00"));
+          await scheduled(DateTime.fromISO("2025-03-02T05:00:01.000+09:00")); // 秒の違いは無視される
+
+          expect(fn).toHaveBeenCalledTimes(2);
+        });
+      });
+
+      describe("時刻が crontab に一致しない場合", () => {
+        it("実行されないこと", async () => {
+          const fn = vi.fn();
+
+          const scheduled = crontab("0 5 * * *", () =>
+            Promise.resolve({ default: fn }),
+          );
+
+          await scheduled(DateTime.fromISO("2025-03-02T04:00:00.000+09:00"));
+          await scheduled(DateTime.fromISO("2025-03-02T06:00:00.000+09:00"));
+
+          expect(fn).toHaveBeenCalledTimes(0);
+        });
+      });
+    });
   });
 
-  test("should not execute the task when the time does not match the crontab", async () => {
-    const fn = vi.fn();
+  describe("時刻が UTC の場合", () => {
+    describe("分指定の場合", () => {
+      describe("時刻が crontab に一致する場合", () => {
+        it("実行されること", async () => {
+          const fn = vi.fn();
 
-    const scheduled = crontab("0 * * * *", () =>
-      Promise.resolve({ default: fn }),
-    );
+          const scheduled = crontab("5 * * * *", () =>
+            Promise.resolve({ default: fn }),
+          );
 
-    await scheduled(DateTime.local(2024, 1, 1, 0, 1, { zone: "asia/tokyo" }));
+          await scheduled(DateTime.fromISO("2025-03-02T07:05:00.000Z"));
+          await scheduled(DateTime.fromISO("2025-03-02T07:05:01.000Z")); // 秒の違いは無視される
 
-    expect(fn).toHaveBeenCalledTimes(0);
+          expect(fn).toHaveBeenCalledTimes(2);
+        });
+      });
+
+      describe("時刻が crontab に一致しない場合", () => {
+        it("実行されないこと", async () => {
+          const fn = vi.fn();
+
+          const scheduled = crontab("5 * * * *", () =>
+            Promise.resolve({ default: fn }),
+          );
+
+          await scheduled(DateTime.fromISO("2025-03-02T07:04:00.000Z"));
+          await scheduled(DateTime.fromISO("2025-03-02T07:06:00.000Z"));
+
+          expect(fn).toHaveBeenCalledTimes(0);
+        });
+      });
+    });
+
+    describe("時指定の場合", () => {
+      describe("時刻が crontab に一致する場合", () => {
+        it("実行されること", async () => {
+          const fn = vi.fn();
+
+          const scheduled = crontab("0 5 * * *", () =>
+            Promise.resolve({ default: fn }),
+          );
+
+          await scheduled(DateTime.fromISO("2025-03-01T20:00:00.000Z"));
+          await scheduled(DateTime.fromISO("2025-03-01T20:00:01.000Z")); // 秒の違いは無視される
+
+          expect(fn).toHaveBeenCalledTimes(2);
+        });
+      });
+
+      describe("時刻が crontab に一致しない場合", () => {
+        it("実行されないこと", async () => {
+          const fn = vi.fn();
+
+          const scheduled = crontab("0 5 * * *", () =>
+            Promise.resolve({ default: fn }),
+          );
+
+          await scheduled(DateTime.fromISO("2025-03-02T04:00:00.000Z"));
+          await scheduled(DateTime.fromISO("2025-03-02T06:00:00.000Z"));
+
+          expect(fn).toHaveBeenCalledTimes(0);
+        });
+      });
+    });
   });
 });

--- a/functions/src/core/crontab.ts
+++ b/functions/src/core/crontab.ts
@@ -19,17 +19,19 @@ export const crontab = (
   }>,
 ) => {
   // crontab の解析
-  const interval = CronExpressionParser.parse(expression, { tz: "asia/tokyo" });
 
   return async (date: DateTime): Promise<void> => {
     // 現在時刻を分切り捨てで取得
     const now = date.setZone("asia/tokyo").startOf("minute");
 
-    // 基準時間を 1 分前に更新
-    interval.reset(now.minus({ minutes: 1 }).toJSDate());
+    const interval = CronExpressionParser.parse(expression, {
+      tz: "asia/tokyo",
+      currentDate: now.minus({ minutes: 1 }).toJSDate(),
+    });
 
     // 1 分前から見た次のインターバルを取得
-    const dateString = interval.next().toDate();
+    const next = interval.next();
+    const dateString = next.toDate();
     const timestamp = DateTime.fromJSDate(dateString, { zone: "asia/tokyo" });
 
     // 現在時刻と一致すれば実行


### PR DESCRIPTION
resetするとtz設定も消えちゃう様子？？

next()で返される値がutcになってしまい、返却値はjstを想定してるので、指定よりも+9時間ズレて実行されてしまう問題を修正