### PR TITLE
ルーターをRiverpodプロバイダーで管理するリファクタリング

### DIFF
--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -32,11 +32,13 @@ void main() async {
   runApp(const ProviderScope(child: MyApp()));
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends ConsumerWidget {
   const MyApp({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final router = ref.watch(routerProvider);
+
     return MaterialApp.router(
       title: 'Nocsis',
       theme: lightTheme,


### PR DESCRIPTION
## 概要

Issue #738 「ルーターをRiverpodプロバイダーで管理するリファクタリング」に対応します。

## 変更内容

### ルーター管理の改善
- グローバル変数だった  を  プロバイダーに変更
-  を  から  に変更し、 を使用

### 認証状態の統合
-  を使用してルーター内で認証状態を管理
- Firebase Auth の非同期取得から同期的なアクセスに変更

## 利点

- ルーターがRiverpodのリアクティブシステムに統合
- 認証状態の変化に自動的に反応
- より宣言的で保守しやすいコード構造

## テスト結果

Analyzing frontend...                                           
No issues found! (ran in 1.6s) でエラーがないことを確認済みです。