### PR TITLE
CI/CDワークフローでlockfileを一貫して遵守するよう修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
         working-directory: ./frontend
         run: flutter pub get --enforce-lockfile
       - name: Generate OpenAPI spec
-        run: pnpm install && pnpm run generate-openapi
+        run: pnpm install --prefer-frozen-lockfile && pnpm run generate-openapi
         working-directory: ./backend
       - name: Run build_runner
         working-directory: ./frontend

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Tools
         uses: jdx/mise-action@v2
       - name: Install dependencies
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
       - name: Build
         run: flutter build web --wasm
       - name: Deploy

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Tools
         uses: jdx/mise-action@v2
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --prefer-frozen-lockfile
       - name: Type Check
         run: pnpm run typecheck
       - name: Lint
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Tools
         uses: jdx/mise-action@v2
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --prefer-frozen-lockfile
       - name: Type Check
         run: pnpm run typecheck
       - name: Lint
@@ -54,9 +54,9 @@ jobs:
       - name: Setup Tools
         uses: jdx/mise-action@v2
       - name: Install dependencies
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
       - name: Generate OpenAPI spec
-        run: pnpm install && pnpm run generate-openapi
+        run: pnpm install --prefer-frozen-lockfile && pnpm run generate-openapi
         working-directory: ./backend
       - name: Run build_runner
         run: flutter pub run build_runner build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Tools
         uses: jdx/mise-action@v2
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --prefer-frozen-lockfile
       - name: Test
         run: pnpm run test
 
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Tools
         uses: jdx/mise-action@v2
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --prefer-frozen-lockfile
       - name: Test
         run: pnpm run test
 
@@ -50,9 +50,9 @@ jobs:
       - name: Setup Tools
         uses: jdx/mise-action@v2
       - name: Install dependencies
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
       - name: Generate OpenAPI spec
-        run: pnpm install && pnpm run generate-openapi
+        run: pnpm install --prefer-frozen-lockfile && pnpm run generate-openapi
         working-directory: ./backend
       - name: Run build_runner
         run: flutter pub run build_runner build


### PR DESCRIPTION
## 概要

frontendのデプロイでは依存関係をインストールする際にlockfileを遵守していましたが、他のCIでは行われていませんでした。これを修正しました。

## 修正内容

### 修正したファイル
- `.github/workflows/test.yml`
- `.github/workflows/lint.yml`
- `.github/workflows/deploy.yml`
- `.github/workflows/deploy_preview.yml`

### 変更内容
- **pnpm系**: `pnpm install` → `pnpm install --prefer-frozen-lockfile`
- **Flutter系**: `flutter pub get` → `flutter pub get --enforce-lockfile`

## 効果

- 🔒 **一貫性**: 全CI/CDでlockfileが遵守されます
- 🎯 **再現可能性**: 開発環境とCI環境で同じ依存関係バージョンを使用
- 🛡️ **セキュリティ**: 意図しない依存関係更新を防止
- 🐛 **デバッグ性**: 依存関係起因の問題特定が容易