### PR TITLE
APIクライアント初期化エラーを修正

### DIFF
--- a/frontend/lib/pages/settings/index.dart
+++ b/frontend/lib/pages/settings/index.dart
@@ -12,11 +12,7 @@ class SettingsTopPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final user = ref.watch(currentUserProvider);
-
-    if (user == null) {
-      return const SizedBox();
-    }
+    final user = ref.watch(authenticatedUserProvider);
 
     final googleEmail = user.providerData
         .firstWhereOrNull((e) => e.providerId == GoogleAuthProvider.PROVIDER_ID)

--- a/frontend/lib/providers/api_client.dart
+++ b/frontend/lib/providers/api_client.dart
@@ -10,7 +10,7 @@ part 'api_client.g.dart';
 
 const String _baseUrl = kDebugMode
     ? 'http://localhost:8080'
-    : 'https://nocsis.app/api';
+    : 'https://nocsis.app';
 
 class BearerAuthInterceptor implements Interceptor {
   final String token;
@@ -30,10 +30,7 @@ class BearerAuthInterceptor implements Interceptor {
 
 @riverpod
 Future<BearerAuthInterceptor> firebaseAuthInterceptor(Ref ref) async {
-  final user = ref.watch(currentUserProvider);
-  if (user == null) {
-    throw Exception('User not authenticated');
-  }
+  final user = ref.watch(authenticatedUserProvider);
 
   final token = await user.getIdToken();
   if (token == null) {

--- a/frontend/lib/providers/user.dart
+++ b/frontend/lib/providers/user.dart
@@ -13,6 +13,19 @@ Stream<User?> userChangesStream(Ref ref) {
 
 @riverpod
 User? currentUser(Ref ref) {
-  final userAsync = ref.watch(userChangesStreamProvider);
-  return userAsync.maybeWhen(data: (user) => user, orElse: () => null);
+  ref.watch(userChangesStreamProvider);
+
+  final auth = ref.watch(firebaseAuthProvider);
+  return auth.currentUser;
+}
+
+@riverpod
+User authenticatedUser(Ref ref) {
+  final user = ref.watch(currentUserProvider);
+
+  if (user == null) {
+    throw Exception('User not authenticated');
+  }
+
+  return user;
 }


### PR DESCRIPTION
## 概要
「New API client initialization failed」エラーを修正しました。

## 修正内容

### 1. baseURL の修正
- 本番環境: https://nocsis.app/api → https://nocsis.app
- これにより生成されたAPIクライアントが正しく https://nocsis.app/api/v1/... にアクセス

### 2. プロバイダーの同期化  
- currentUser: Firebase Auth の currentUser を同期的に返す
- authenticatedUser: 認証前提のページ用（nullの場合は例外）
- userChangesStream で状態変化を監視しつつ、実際の値は同期的に取得

### 3. 初回null問題の解決
- Firebase Auth の userChanges() は初回nullを返すが、認証済みページでは auth.currentUser を直接使用することで回避
- ルーターレベルで認証チェック済みのため、同期的なアプローチが適切

### 4. 設定ページの修正
- authenticatedUserProvider を使用して直接 User を取得
- AsyncValue や FutureBuilder が不要になり、コードが簡潔に

関連: #744