### PR TITLE
フロントエンドの日時表示をUTCからローカル時刻に修正

### DIFF
--- a/frontend/lib/components/personal/class_list.dart
+++ b/frontend/lib/components/personal/class_list.dart
@@ -19,8 +19,12 @@ class ClassListView extends StatelessWidget {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: (items).map((data) {
-              final String startAt = DateFormat("HH:mm").format(data.startAt);
-              final String endAt = DateFormat("HH:mm").format(data.endAt);
+              final String startAt = DateFormat(
+                "HH:mm",
+              ).format(data.startAt.toLocal());
+              final String endAt = DateFormat(
+                "HH:mm",
+              ).format(data.endAt.toLocal());
 
               return BasicCard(
                 primary: Text(data.title),

--- a/frontend/lib/components/personal/event_list.dart
+++ b/frontend/lib/components/personal/event_list.dart
@@ -22,7 +22,7 @@ class EventListView extends StatelessWidget {
               // FIXME: swagger-dart-code-generator の制限により anyOf が dynamic 型になってしまうので、String として扱う
               final DateTime? startDate = DateTime.tryParse(
                 data.startAt as String,
-              );
+              )?.toLocal();
 
               final String dateText = startDate != null
                   ? DateFormat("M月d日").format(startDate)

--- a/frontend/lib/pages/main/events/page.dart
+++ b/frontend/lib/pages/main/events/page.dart
@@ -35,7 +35,9 @@ final eventsProvider = FutureProvider.family<List<MonthEventGroup>, String>((
 
     // 月毎にグループ化
     final monthGroups = groupBy(events, (Event event) {
-      final DateTime? startDate = DateTime.tryParse(event.startAt as String);
+      final DateTime? startDate = DateTime.tryParse(
+        event.startAt as String,
+      )?.toLocal();
       return DateFormat('yyyy-MM').format(startDate!);
     });
 
@@ -101,7 +103,7 @@ class EventsView extends ConsumerWidget {
                             ),
                             // TODO: 日を跨いだりする場合の表示に対応する
                             secondary: Text(
-                              DateFormat("M月d日").format(startDate!),
+                              DateFormat("M月d日").format(startDate!.toLocal()),
                             ),
                           );
                         }).toList(),


### PR DESCRIPTION
# フロントエンドの日時表示をUTCからローカル時刻に修正

## 概要

フロントエンドでAPIから受信した日時データがUTC時刻で表示されていた問題を修正しました。
`DateTime.parse()`や`DateTime.tryParse()`で取得した日時に対して`.toLocal()`を適用することで、正しいローカル時刻（JST）での表示に修正しています。

## 修正内容

### 1. `/frontend/lib/components/personal/class_list.dart`
- クラスの開始時刻・終了時刻表示で`.toLocal()`を適用

### 2. `/frontend/lib/components/personal/event_list.dart`  
- イベントの日付表示で`.toLocal()`を適用

### 3. `/frontend/lib/pages/main/events/page.dart`
- 月別グループ化処理で`.toLocal()`を適用
- イベント表示での日付フォーマットで`.toLocal()`を適用

## 影響範囲

- **授業時刻表示**: UTC表示 → JST表示
- **イベント日付表示**: UTC表示 → JST表示  
- **月別イベントグループ化**: UTC基準 → JST基準

## テスト

- [ ] 授業時刻が正しいJST時刻で表示されることを確認
- [ ] イベント日付が正しいJST時刻で表示されることを確認
- [ ] 月境界のイベントが正しい月に分類されることを確認

## 背景

APIクライアントで受信した日時データがUTC時刻として解釈され、フロントエンドでの表示時にタイムゾーン変換が適用されていませんでした。これにより、実際の時刻より9時間早い時刻で表示される問題が発生していました。
