### PR TITLE
dependabot設定の改善: 週次実行・グループ化・GitHub Actions管理を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,14 +8,48 @@ updates:
   - package-ecosystem: "npm"
     directory: "/functions"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "friday"
+    groups:
+      patch-updates:
+        update-types:
+          - "patch"
+    ignore:
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"
     directory: "/backend"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "friday"
+    groups:
+      patch-updates:
+        update-types:
+          - "patch"
+    ignore:
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "pub"
     directory: "/frontend"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "friday"
+    groups:
+      patch-updates:
+        update-types:
+          - "patch"
+      minor-updates:
+        update-types:
+          - "minor"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+    groups:
+      actions-updates:
+        update-types:
+          - "patch"


### PR DESCRIPTION
# Dependabot設定の改善

## 変更内容

### スケジュール変更
- **頻度**: daily → weekly (金曜日)
- **理由**: PR数の削減とレビュー負荷の軽減

### パッケージ更新のグループ化
- **npm (functions/backend)**: パッチバージョンをグループ化
- **pub (frontend)**: パッチ・マイナーバージョンをグループ化
- **理由**: 関連する更新をまとめて効率的にレビュー

### GitHub Actions管理の追加
- **新規追加**: github-actionsエコシステムの監視
- **グループ化**: パッチバージョンのみ（安全性重視）
- **理由**: セキュリティアップデートの自動化

### 特定パッケージの除外
- **@types/node**: メジャーバージョンアップデートを無視
- **理由**: Node.jsバージョンと密接に関わるため手動管理

## 期待される効果

1. **PR数削減**: 週1回のまとめ更新
2. **レビュー効率化**: 関連更新のグループ化
3. **セキュリティ向上**: GitHub Actionsの自動更新
4. **安定性確保**: 破壊的変更の手動管理
