### PR TITLE
GitHub Actionsのバージョンをコミットハッシュでピン留め

### DIFF
--- a/.github/workflows/create_release_pr.yml
+++ b/.github/workflows/create_release_pr.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Create Release Pull Request
         run: |
           pr_title=$(echo "Release $(TZ=Asia/Tokyo date +'%Y-%m-%d')")

--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Dependabot metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # v2.4.0
         id: metadata
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,9 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Setup Tools
-        uses: jdx/mise-action@v3
+        uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       - name: Install dependencies
         working-directory: ./functions
         run: pnpm install --prefer-frozen-lockfile
@@ -35,7 +35,7 @@ jobs:
         working-directory: ./functions
         run: pnpm run build
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: functions-build
           path: ./functions/dist
@@ -46,9 +46,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Setup Tools
-        uses: jdx/mise-action@v3
+        uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       - name: Install dependencies
         working-directory: ./frontend
         run: flutter pub get --enforce-lockfile
@@ -62,7 +62,7 @@ jobs:
         working-directory: ./frontend
         run: flutter build web --wasm
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: frontend-build
           path: ./frontend/build
@@ -77,18 +77,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Download Functions Build Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: functions-build
           path: ./functions/dist
       - name: Setup Tools
-        uses: jdx/mise-action@v3
+        uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       - name: Install dependencies
         run: pnpm install --prefer-frozen-lockfile; cd functions && pnpm install --prefer-frozen-lockfile
       - name: Auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
         with:
           workload_identity_provider: projects/219141289630/locations/global/workloadIdentityPools/github-action/providers/deploy-nocsis
           service_account: gh-actions-deploy@class-clock-40088.iam.gserviceaccount.com
@@ -104,16 +104,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Setup Tools
-        uses: jdx/mise-action@v3
+        uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       - name: Auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
         with:
           workload_identity_provider: projects/219141289630/locations/global/workloadIdentityPools/github-action/providers/deploy-nocsis
           service_account: gh-actions-deploy@class-clock-40088.iam.gserviceaccount.com
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
       - name: Deploy Backend
         run: gcloud run deploy backend --source ./backend --project class-clock-40088 --region asia-northeast1 --no-traffic
       - name: Set Traffic
@@ -130,19 +130,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Download Frontend Build Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: frontend-build
           path: ./frontend/build
       - name: Setup Tools
-        uses: jdx/mise-action@v3
+        uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       - name: Install dependencies
         run: pnpm install --prefer-frozen-lockfile
       - name: Deploy Frontend
         id: deploy_frontend
-        uses: FirebaseExtended/action-hosting-deploy@v0
+        uses: FirebaseExtended/action-hosting-deploy@73212fc153444869d3e433816aab02624792fcef # v0.10.0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.DEPLOY_FIREBASE_HOSTING_SERVICE_ACCOUNT }}

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -23,15 +23,15 @@ jobs:
         working-directory: ./frontend
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Setup Tools
-        uses: jdx/mise-action@v3
+        uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       - name: Install dependencies
         run: flutter pub get --enforce-lockfile
       - name: Build
         run: flutter build web --wasm
       - name: Deploy
-        uses: FirebaseExtended/action-hosting-deploy@v0
+        uses: FirebaseExtended/action-hosting-deploy@73212fc153444869d3e433816aab02624792fcef # v0.10.0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.DEPLOY_FIREBASE_HOSTING_SERVICE_ACCOUNT }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,9 +16,9 @@ jobs:
         working-directory: ./functions
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Setup Tools
-        uses: jdx/mise-action@v3
+        uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       - name: Install dependencies
         run: pnpm install --prefer-frozen-lockfile
       - name: Type Check
@@ -33,9 +33,9 @@ jobs:
         working-directory: ./backend
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Setup Tools
-        uses: jdx/mise-action@v3
+        uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       - name: Install dependencies
         run: pnpm install --prefer-frozen-lockfile
       - name: Type Check
@@ -50,9 +50,9 @@ jobs:
         working-directory: ./frontend
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Setup Tools
-        uses: jdx/mise-action@v3
+        uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       - name: Install dependencies
         run: flutter pub get --enforce-lockfile
       - name: Generate OpenAPI spec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,9 @@ jobs:
         working-directory: ./functions
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Setup Tools
-        uses: jdx/mise-action@v3
+        uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       - name: Install dependencies
         run: pnpm install --prefer-frozen-lockfile
       - name: Test
@@ -31,9 +31,9 @@ jobs:
         working-directory: ./backend
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Setup Tools
-        uses: jdx/mise-action@v3
+        uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       - name: Install dependencies
         run: pnpm install --prefer-frozen-lockfile
       - name: Test
@@ -46,9 +46,9 @@ jobs:
         working-directory: ./frontend
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Setup Tools
-        uses: jdx/mise-action@v3
+        uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       - name: Install dependencies
         run: flutter pub get --enforce-lockfile
       - name: Generate OpenAPI spec


### PR DESCRIPTION
# GitHub Actionsのバージョンをコミットハッシュでピン留め

## 概要

GitHub Actionsのセキュリティ向上のため、すべてのアクションをコミットハッシュでピン留めしました。

## 変更内容

### セキュリティ強化
- 全35箇所のGitHub Actionsをコミットハッシュでピン留め
- バージョンコメントを追加して可読性を保持
- 供給チェーン攻撃対策を実装

### 更新されたアクション

| アクション | 旧バージョン | 新ハッシュ | バージョン |
|-----------|-------------|-----------|-----------|
| actions/checkout | v4 | 08eba0b | v4.3.0 |
| jdx/mise-action | v3 | 5ac50f7 | v3.2.0 |
| google-github-actions/auth | v2 | c200f36 | v2.1.13 |
| FirebaseExtended/action-hosting-deploy | v0 | 73212fc | v0.10.0 |
| actions/upload-artifact | v4 | ea165f8 | v4.6.2 |
| actions/download-artifact | v4 | d3f86a1 | v4.3.0 |
| google-github-actions/setup-gcloud | v2 | e427ad8 | v2.2.1 |
| dependabot/fetch-metadata | v2 | 08eff52 | v2.4.0 |

### 対象ファイル
- `.github/workflows/test.yml`
- `.github/workflows/lint.yml`
- `.github/workflows/deploy.yml`
- `.github/workflows/deploy_preview.yml`
- `.github/workflows/create_release_pr.yml`
- `.github/workflows/dependabot_auto_merge.yml`

## メリット

1. **完全な再現性**: 同じコミットハッシュは永続的に同じコードを指します
2. **供給チェーン攻撃対策**: タグの書き換えによる攻撃を防げます
3. **dependabot対応**: ハッシュ指定でもdependabotが自動更新してくれます
4. **可読性**: コメントでバージョンが一目でわかります

## 動作確認

- [ ] テストワークフローが正常に動作する
- [ ] リントワークフローが正常に動作する
- [ ] デプロイワークフローが正常に動作する
