### PR TITLE
ci(workflow): release PR作成のトークン適用範囲を限定

### DIFF
--- a/.github/workflows/create_release_pr.yml
+++ b/.github/workflows/create_release_pr.yml
@@ -6,9 +6,6 @@ on:
 
 permissions: {}
 
-env:
-  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
   create_release_pr:
     runs-on: ubuntu-latest
@@ -19,6 +16,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Create Release Pull Request
+        env:
+          GH_TOKEN: ${{ secrets.CREATE_RELEASE_PR_TOKEN }}
         run: |
           pr_title=$(echo "Release $(TZ=Asia/Tokyo date +'%Y-%m-%d')")
 


### PR DESCRIPTION
release PR作成 workflowを修正しました。
-  を使用するように変更
- トークンの適用範囲をステップ内に限定