### PR TITLE
feat: hot reloadの実験的フラグを削除

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,8 +5,7 @@
       "name": "Run Flutter",
       "request": "launch",
       "type": "dart",
-      "program": "frontend/lib/main.dart",
-      "args": ["--web-experimental-hot-reload"]
+      "program": "frontend/lib/main.dart"
     },
     {
       "name": "Run Flutter (profile mode)",


### PR DESCRIPTION
Resolves #870

## 概要

Flutter 3.35 で Web の Hot Reload がデフォルトで有効になったため、VS Code のデバッグ設定 (`.vscode/launch.json`) に含まれていた実験的フラグ `--web-experimental-hot-reload` を削除しました。

この変更により、不要なオプション指定がなくなり、設定がシンプルになります。
