### PR TITLE
APIの戻り値型を明示して型エラーになるようにする

### DIFF
--- a/backend/src/controllers/v1/classes_controller.ts
+++ b/backend/src/controllers/v1/classes_controller.ts
@@ -42,6 +42,7 @@ const classesResponseSchema = z
     items: z.array(classSchema).openapi({ description: "授業のリスト" }),
   })
   .openapi({ description: "授業の一覧を取得する際のレスポンス" });
+type ClassesResponse = z.infer<typeof classesResponseSchema>;
 
 classesRoutes.get(
   "/:groupId/classes",
@@ -157,7 +158,7 @@ classesRoutes.get(
       });
     });
 
-    return c.json({
+    return c.json<ClassesResponse>({
       items: classes,
     });
   },

--- a/backend/src/controllers/v1/dayduty_controller.ts
+++ b/backend/src/controllers/v1/dayduty_controller.ts
@@ -25,6 +25,7 @@ const paramSchema = z
     groupId: z.string().openapi({ description: "グループのID" }),
   })
   .openapi({ description: "日直情報を取得する際のパラメータ" });
+type DaydutyResponse = z.infer<typeof daydutyResponseSchema>;
 
 daydutRoutes.get(
   "/:groupId/dayduty",
@@ -116,7 +117,7 @@ daydutRoutes.get(
 
       const validatedResponse = daydutyResponseSchema.parse(classmate);
 
-      return c.json(validatedResponse, 200);
+      return c.json<DaydutyResponse>(validatedResponse, 200);
     } catch (error) {
       console.error("Error in dayduty controller:", error);
       throw error;

--- a/backend/src/controllers/v1/events_controller.ts
+++ b/backend/src/controllers/v1/events_controller.ts
@@ -49,6 +49,7 @@ const eventsResponseSchema = z
     items: z.array(eventSchema).openapi({ description: "イベントのリスト" }),
   })
   .openapi({ description: "イベントの一覧を取得する際のレスポンス" });
+type EventsResponse = z.infer<typeof eventsResponseSchema>;
 
 eventsRoutes.get(
   "/:groupId/events",
@@ -147,7 +148,7 @@ eventsRoutes.get(
       });
     });
 
-    return c.json({
+    return c.json<EventsResponse>({
       items: eventItems,
     });
   },

--- a/backend/src/controllers/v1/group_controller.ts
+++ b/backend/src/controllers/v1/group_controller.ts
@@ -1,4 +1,3 @@
-import assert from "node:assert";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { describeRoute, resolver, validator } from "hono-openapi";
@@ -31,6 +30,7 @@ const patchJsonSchema = groupSchema
     ref: "GroupPatchJson",
     description: "グループの更新に使用するJSONデータ",
   });
+type GroupResponse = z.infer<typeof groupSchema>;
 
 groupRoutes
   .get(
@@ -84,13 +84,12 @@ groupRoutes
         });
       }
 
-      const group = groupSnapshot.data();
-      assert(group);
-
-      return c.json({
+      const group = groupSchema.parse({
         id: groupSnapshot.id,
-        ...group,
+        ...groupSnapshot.data(),
       });
+
+      return c.json<GroupResponse>(group);
     },
   )
   .patch(
@@ -154,12 +153,11 @@ groupRoutes
       await groupRef.update(data);
 
       const updatedGroupSnapshot = await groupRef.get();
-      const updatedGroup = updatedGroupSnapshot.data();
-      assert(updatedGroup);
-
-      return c.json({
+      const updatedGroup = groupSchema.parse({
         id: updatedGroupSnapshot.id,
-        ...updatedGroup,
+        ...updatedGroupSnapshot.data(),
       });
+
+      return c.json<GroupResponse>(updatedGroup);
     },
   );

--- a/backend/src/controllers/v1/weather_controller.ts
+++ b/backend/src/controllers/v1/weather_controller.ts
@@ -24,6 +24,7 @@ const paramSchema = z
     groupId: z.string().openapi({ description: "グループのID" }),
   })
   .openapi({ description: "パスパラメータ" });
+type WeatherDataResponse = z.infer<typeof weatherDataSchema>;
 
 weatherRoutes.get(
   "/:groupId/weather/now",
@@ -98,6 +99,6 @@ weatherRoutes.get(
       .slice(1, 4)
       .map((v) => getWeatherNameById(v.weather[0].id));
 
-    return c.json({ current, hourly, threeHour });
+    return c.json<WeatherDataResponse>({ current, hourly, threeHour });
   },
 );

--- a/backend/src/services/open_weather_map_service.ts
+++ b/backend/src/services/open_weather_map_service.ts
@@ -115,7 +115,7 @@ const WeatherIdToName = [
  *
  * ID 一覧: https://openweathermap.org/weather-conditions
  */
-export const getWeatherNameById = (id: number): string => {
+export const getWeatherNameById = (id: number): WeatherName => {
   for (const [pattern, name] of WeatherIdToName) {
     if (pattern.test(id.toString())) return name;
   }


### PR DESCRIPTION
## 概要

zod で定義しているレスポンススキーマから型を取り出して `c.json<Schema>(...)` で明示することで、API レスポンスの型エラーを検出できるようにしました。

## 変更内容

### 各コントローラーにレスポンス型を定義

以下のコントローラーで、zod スキーマから `z.infer<typeof スキーマ名>` で型を定義し、`c.json<型>()` で明示的に型を指定しました:

- `classes_controller.ts`: `ClassesResponse`
- `user_controller.ts`: `UserJoinedGroupsResponse`
- `events_controller.ts`: `EventsResponse`
- `dayduty_controller.ts`: `DaydutyResponse`
- `weather_controller.ts`: `WeatherDataResponse`
- `group_controller.ts`: `GroupResponse`

### Firestore データのバリデーション強化

- **group_controller.ts**: データ取得時に `groupSchema.parse()` でバリデーション、不要な `assert` を削除
- **user_controller.ts**: 配列全体を `z.array(groupSchema).parse()` でバリデーション（パフォーマンス向上）

### 型定義の改善

- **open_weather_map_service.ts**: `getWeatherNameById` の戻り値型を `string` から `WeatherName` に修正

## 効果

- **コンパイル時の型チェック**: レスポンスの型が正しくない場合、コンパイル時にエラーが検出される
- **ランタイムバリデーション**: zod によるバリデーションでデータの整合性を保証
- **型安全性の向上**: Firestore の汎用型からの変換を明示的に行い、型の不一致を防ぐ

Closes #894
