### PR TITLE
chore: remove Corepack from backend Docker pnpm setup

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,6 +2,9 @@ FROM node:22-slim AS base
 WORKDIR /app
 
 ENV NODE_ENV=production
+
+FROM base AS builder-base
+
 ENV PNPM_HOME=/root/.local/share/pnpm
 ENV PATH=${PNPM_HOME}:${PATH}
 ENV PNPM_VERSION=10.11.0
@@ -13,7 +16,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 
-FROM base AS builder
+FROM builder-base AS builder
 
 COPY . .
 RUN pnpm install --frozen-lockfile && \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,15 +5,9 @@ ENV NODE_ENV=production
 
 FROM base AS builder-base
 
-ENV PNPM_HOME=/root/.local/share/pnpm
-ENV PATH=${PNPM_HOME}:${PATH}
 ENV PNPM_VERSION=10.11.0
 
-RUN apt-get update && \
-    apt-get install --yes --no-install-recommends wget ca-certificates && \
-    wget -qO- https://get.pnpm.io/install.sh | env PNPM_VERSION=${PNPM_VERSION} ENV="$HOME/.shrc" SHELL="$(which sh)" sh - && \
-    apt-get purge --yes --auto-remove wget && \
-    rm -rf /var/lib/apt/lists/*
+RUN npm install --global pnpm@${PNPM_VERSION}
 
 
 FROM builder-base AS builder

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,8 +2,15 @@ FROM node:22-slim AS base
 WORKDIR /app
 
 ENV NODE_ENV=production
+ENV PNPM_HOME=/root/.local/share/pnpm
+ENV PATH=${PNPM_HOME}:${PATH}
+ENV PNPM_VERSION=10.11.0
 
-RUN corepack enable
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends wget ca-certificates && \
+    wget -qO- https://get.pnpm.io/install.sh | env PNPM_VERSION=${PNPM_VERSION} ENV="$HOME/.shrc" SHELL="$(which sh)" sh - && \
+    apt-get purge --yes --auto-remove wget && \
+    rm -rf /var/lib/apt/lists/*
 
 
 FROM base AS builder

--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,4 @@
 [tools]
 node = "22"
-pnpm = "10"
+pnpm = "10.11.0"
 flutter = "3.41.4"


### PR DESCRIPTION
## Summary
- remove Corepack usage from the backend Dockerfile
- install pnpm 10.11.0 in Docker using the official specific-version install script
- align the local mise-managed pnpm version with Docker

## Why this is minimal
- keeping dev and Docker on the same pnpm version without using `packageManager` requires touching the Docker pin and the local tool pin
- under the current setup, that means only `backend/Dockerfile` and `mise.toml`

## Validation
- docker build -f /Users/cano/dev/nocsis/backend/Dockerfile --target base /Users/cano/dev/nocsis/backend

Closes #1055