### PR TITLE
fix: frontend login redirect white screen

### DIFF
--- a/frontend/lib/providers/auth.dart
+++ b/frontend/lib/providers/auth.dart
@@ -1,9 +1,11 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'firebase.dart';
 
 part 'auth.g.dart';
 
 @riverpod
-Stream<User?> auth(_) {
-  return FirebaseAuth.instance.authStateChanges();
+Stream<User?> auth(Ref ref) {
+  final auth = ref.watch(firebaseAuthProvider);
+  return auth.authStateChanges();
 }

--- a/frontend/lib/routes/router.dart
+++ b/frontend/lib/routes/router.dart
@@ -135,7 +135,7 @@ GoRouter router(Ref ref) {
     refreshListenable: refresher,
     redirect: (context, state) async {
       return redirectNotLoggedInUser(state) ??
-          redirectLoggedInUser(state) ??
+          await redirectLoggedInUser(state) ??
           await redirectFromTopPage(state.uri);
     },
   );

--- a/frontend/lib/routes/router.dart
+++ b/frontend/lib/routes/router.dart
@@ -22,7 +22,7 @@ import 'package:nocsis/pages/main/layout.dart';
 import 'package:nocsis/pages/settings/index.dart';
 import 'package:nocsis/pages/settings/layout.dart';
 import 'package:nocsis/providers/auth.dart';
-import 'package:nocsis/providers/user.dart';
+import 'package:nocsis/providers/firebase.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -99,8 +99,8 @@ GoRouter router(Ref ref) {
         : "/groups/${firstUserJoinedGroup.id}${uri.path}";
   }
 
-  Future<String?> redirectNotLoggedInUser(GoRouterState state) async {
-    final currentUser = await ref.read(userChangesStreamProvider.future);
+  String? redirectNotLoggedInUser(GoRouterState state) {
+    final currentUser = ref.read(firebaseAuthProvider).currentUser;
     final isLoggedIn = currentUser != null;
 
     if (isLoggedIn || state.matchedLocation == LoginPageRoute().location) {
@@ -112,7 +112,7 @@ GoRouter router(Ref ref) {
   }
 
   Future<String?> redirectLoggedInUser(GoRouterState state) async {
-    final currentUser = await ref.read(userChangesStreamProvider.future);
+    final currentUser = ref.read(firebaseAuthProvider).currentUser;
     final isLoggedIn = currentUser != null;
 
     if (!isLoggedIn || state.matchedLocation != LoginPageRoute().location) {
@@ -134,8 +134,8 @@ GoRouter router(Ref ref) {
     routes: $appRoutes,
     refreshListenable: refresher,
     redirect: (context, state) async {
-      return await redirectNotLoggedInUser(state) ??
-          await redirectLoggedInUser(state) ??
+      return redirectNotLoggedInUser(state) ??
+          redirectLoggedInUser(state) ??
           await redirectFromTopPage(state.uri);
     },
   );

--- a/frontend/test/routes/router_test.dart
+++ b/frontend/test/routes/router_test.dart
@@ -1,0 +1,54 @@
+import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nocsis/providers/firebase.dart';
+import 'package:nocsis/routes/router.dart';
+
+void main() {
+  testWidgets('未ログインで保護ページを開くとログイン画面へ直接遷移する', (
+    tester,
+  ) async {
+    tester.binding.platformDispatcher.defaultRouteNameTestValue =
+        '/groups/test-group/console';
+
+    final container = ProviderContainer(
+      overrides: [
+        firebaseAuthProvider.overrideWithValue(MockFirebaseAuth(signedIn: false)),
+      ],
+    );
+
+    addTearDown(container.dispose);
+    addTearDown(tester.binding.platformDispatcher.clearDefaultRouteNameTestValue);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: Consumer(
+          builder: (context, ref, child) {
+            final router = ref.watch(routerProvider);
+            return MaterialApp.router(routerConfig: router);
+          },
+        ),
+      ),
+    );
+
+    expect(find.text('管理コンソール'), findsNothing);
+
+    await tester.pump();
+
+    expect(
+      container.read(routerProvider).routeInformationProvider.value.uri.toString(),
+      startsWith('/login?continue-uri='),
+    );
+    expect(find.text('ログイン'), findsWidgets);
+    expect(find.text('Google で続行'), findsOneWidget);
+    expect(find.text('管理コンソール'), findsNothing);
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('ログイン'), findsWidgets);
+    expect(find.text('Google で続行'), findsOneWidget);
+    expect(find.text('管理コンソール'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary
- remove async auth stream reads from router redirects
- read FirebaseAuth currentUser synchronously for login redirect decisions
- add a router widget test for unauthenticated deep-link access

## Testing
- flutter test
- flutter analyze
- flutter build web