### PR TITLE
feat: グループごとに日直通知を無効化できるようにする

### DIFF
--- a/functions/src/services/notify_datduty/notify_dayduty.test.ts
+++ b/functions/src/services/notify_datduty/notify_dayduty.test.ts
@@ -31,6 +31,35 @@ describe("notifyDayduty", () => {
     );
   });
 
+  describe("dayduty_notification_enabledがfalseのグループがある場合", async () => {
+    beforeEach(async () => {
+      const firestore = getFirestore(firebaseApp);
+
+      await firestore
+        .doc("groups/group_disabled")
+        .set({ dayduty_notification_enabled: false });
+    });
+
+    it("そのグループの通知処理は呼び出されないこと", async () => {
+      const mockedNotifyDayDutyPerGroup = vi
+        .spyOn(notifyDayDutyPerGroupModule, "notifyDayDutyPerGroup")
+        .mockImplementation(async () => {});
+
+      const date = DateTime.local(2025, 1, 1);
+      await notifyDayDuty(date);
+
+      expect(mockedNotifyDayDutyPerGroup).toHaveBeenCalledTimes(1);
+      expect(mockedNotifyDayDutyPerGroup).toHaveBeenCalledWith(
+        { id: "group_1" },
+        date,
+      );
+      expect(mockedNotifyDayDutyPerGroup).not.toHaveBeenCalledWith(
+        { id: "group_disabled" },
+        date,
+      );
+    });
+  });
+
   describe("通知処理でエラーが発生した場合", async () => {
     beforeEach(async () => {
       const firestore = getFirestore(firebaseApp);

--- a/functions/src/services/notify_datduty/notify_dayduty.test.ts
+++ b/functions/src/services/notify_datduty/notify_dayduty.test.ts
@@ -31,7 +31,7 @@ describe("notifyDayduty", () => {
     );
   });
 
-  describe("dayduty_notification_enabledがfalseのグループがある場合", async () => {
+  describe("dayduty_notification_enabledがfalseのグループがある場合", () => {
     beforeEach(async () => {
       const firestore = getFirestore(firebaseApp);
 

--- a/functions/src/services/notify_datduty/notify_dayduty.ts
+++ b/functions/src/services/notify_datduty/notify_dayduty.ts
@@ -10,9 +10,9 @@ export const notifyDayDuty: CrontabHandler = async (timestamp) => {
   const firestore = getFirestore(firebaseApp);
 
   const groupsSnapshot = await firestore.collection("groups").get();
-  const groups = groupsSnapshot.docs.map((doc) => ({
-    id: doc.id,
-  }));
+  const groups = groupsSnapshot.docs
+    .filter((doc) => doc.data().dayduty_notification_enabled !== false)
+    .map((doc) => ({ id: doc.id }));
 
   await Promise.allSettled(
     groups.map((group) =>

--- a/functions/src/services/notify_datduty/notify_dayduty.ts
+++ b/functions/src/services/notify_datduty/notify_dayduty.ts
@@ -11,7 +11,7 @@ export const notifyDayDuty: CrontabHandler = async (timestamp) => {
 
   const groupsSnapshot = await firestore.collection("groups").get();
   const groups = groupsSnapshot.docs
-    .filter((doc) => doc.data().dayduty_notification_enabled !== false)
+    .filter((doc) => doc.get("dayduty_notification_enabled") !== false)
     .map((doc) => ({ id: doc.id }));
 
   await Promise.allSettled(


### PR DESCRIPTION
## 変更内容

Firestore の `groups/{groupId}` ドキュメントに `dayduty_notification_enabled: false` を設定することで、そのグループの日直通知を無効化できるようにしました。

## 変更点

- `notify_dayduty.ts`: グループ取得時に `dayduty_notification_enabled !== false` でフィルター（フィールド未設定のグループはデフォルトで通知される）
- `notify_dayduty.test.ts`: `dayduty_notification_enabled: false` のグループがスキップされるテストを追加

## 使用方法

特定クラスで通知を止めたい場合は、Firestore コンソールで該当グループのドキュメントに以下を追加してください。

```
dayduty_notification_enabled: false
```